### PR TITLE
Add simple queue, stack, and deque examples

### DIFF
--- a/data_structures/deque.rb
+++ b/data_structures/deque.rb
@@ -1,0 +1,119 @@
+# A double-ended queue (or deque) implemented as a double-linked list.
+#
+# Double-ended queues give you constant-time (i.e. O(1)) lookup for both the
+# head and the tail of the list and also allow you to easily traverse in either
+# direction through the queue.
+#
+# Random access via the `#[]` method is in linear time (i.e. O(n)) because there
+# is no direct access to any elements other than the head and the tail.
+#
+# Note: This deque is not thread-safe.
+class Deque
+  include Enumerable
+
+  def initialize
+    @head = nil
+    @tail = nil
+  end
+
+  def [](index)
+    each.lazy.map { |e| e }.first(index + 1)[index]
+  end
+
+  def clear
+    @head = @tail = nil
+  end
+
+  def each
+    return to_enum(__callee__) unless block_given?
+    return unless @head
+
+    node = @head
+
+    loop do
+      yield node.value
+      node = node.next or break
+    end
+  end
+
+  def head
+    @head && @head.value
+  end
+
+  def inspect
+    nodes = map { |node| "#{node} <->" }
+
+    if nodes.any?
+      last_node = nodes.pop[0...-4]
+      nodes.push(last_node)
+    end
+
+    "#<Deque [#{nodes.join(' ')}]>"
+  end
+
+  def pop
+    return unless @tail
+
+    value, @tail = @tail.value, @tail.prev
+    value
+  end
+
+  def push(value)
+    if @tail
+      @tail = @tail.append(value)
+    else
+      @tail = @head = Node.new(value)
+    end
+
+    self
+  end
+
+  def reverse_each
+    return to_enum(__callee__) unless block_given?
+    return unless @tail
+
+    node = @tail
+
+    loop do
+      yield node.value
+      node = node.prev or break
+    end
+  end
+
+  def shift
+    return unless @head
+
+    value, @head = @head.value, @head.next
+    value
+  end
+
+  def tail
+    @tail && @tail.value
+  end
+
+  def unshift(value)
+    if @head
+      @head = @head.prepend(value)
+    else
+      @head = @tail = Node.new(value)
+    end
+
+    self
+  end
+
+  private
+
+  Node = Struct.new(:value, :prev, :next) do
+    def append(value)
+      self.next = Node.new(value, self, nil)
+    end
+
+    def inspect
+      value
+    end
+
+    def prepend(value)
+      self.prev = Node.new(value, nil, self)
+    end
+  end
+end

--- a/data_structures/simple_queue.rb
+++ b/data_structures/simple_queue.rb
@@ -1,0 +1,73 @@
+# A simple first-in, first-out (FIFO) queue.
+#
+# Queues are simple data structures that give you access to a first-in,
+# first-out collection of data. You can only ever add elements to the end of
+# the queue and you can only ever remove elements form the front of the queue.
+#
+# Enqueuing and dequeuing are both in constant time (i.e. O(1)).
+#
+# Note: This code should not be used for any purpose other than for learning.
+# There is a built-in `Queue` class in the Ruby standard library that will be
+# more performant than this one.
+#
+# Note: This queue is not thread-safe.
+#
+# Note: You can also implement a queue on top of an Array using `Array#push`
+# (enqueue) and `Array#shift` (dequeue) or `Array#unshift` (enqueue) and
+# `Array#pop` (dequeue).
+class SimpleQueue
+  include Enumerable
+
+  def initialize
+    @head = @tail = nil
+    @size = 0
+  end
+
+  attr_reader :size
+
+  def dequeue
+    return unless @head
+
+    value, @head = @head.value, @head.next
+    @size -= 1
+    value
+  end
+
+  def each
+    return to_enum(__callee__) unless block_given?
+    return unless @head
+
+    node = @head
+
+    loop do
+      yield node.value
+      node = node.next or break
+    end
+  end
+
+  def enqueue(element)
+    if @tail
+      @tail = @tail.append(element)
+    else
+      @tail = @head = Element.new(element)
+    end
+    @size += 1
+    self
+  end
+
+  def inspect
+    "#<SimpleQueue #{to_a.inspect}>"
+  end
+
+  def peek
+    @head && @head.value
+  end
+
+  private
+
+  Element = Struct.new(:value, :next) do
+    def append(value)
+      self.next = self.class.new(value)
+    end
+  end
+end

--- a/data_structures/stack.rb
+++ b/data_structures/stack.rb
@@ -1,0 +1,59 @@
+# A last-in, first-out (LIFO) stack.
+#
+# Stacks are simple data structures that give you access to a last-in,
+# first-out collection of data. You can only ever add elements to and remove
+# elements from the top of the stack.
+#
+# Enqueuing and dequeuing are both in constant time (i.e. O(1)).
+#
+# Note: This queue is not thread-safe.
+#
+# Note: You can also implement a stack on top of an Array using `Array#shift`
+# and `Array#pop` or `Array#shift` and `Array#unshift`.
+class Stack
+  include Enumerable
+
+  def initialize
+    @head = nil
+    @size = 0
+  end
+
+  attr_reader :size
+
+  def each
+    return to_enum(__callee__) unless block_given?
+    return unless @head
+
+    node = @head
+    loop do
+      yield node.value
+      node = node.next or break
+    end
+  end
+
+  def inspect
+    "#<Stack #{to_a.inspect}>"
+  end
+
+  def peek
+    @head && @head.value
+  end
+
+  def pop
+    return unless @head
+
+    value, @head = @head.value, @head.next
+    @size -= 1
+    value
+  end
+
+  def push(value)
+    @head = new_head = Frame.new(value, @head)
+    @size += 1
+    self
+  end
+
+  private
+
+  Frame = Struct.new(:value, :next)
+end


### PR DESCRIPTION
Three simple data structures that programmers should know about are:

* Stack
* Queue
* Deque

This implements simple examples of all three using linked lists (and in the case of the deque, a double-linked list).

I mixed in `Enumerable` into all of these, even though the enumerability of the data structure isn't necessarily supposed to be there. I was looking at the Python implementation of `collections.deque` and it allows you to convert a deque into a list through the `list` function. The equivalent of this is `#to_a` in Ruby, so I went ahead and used Enumerable for that.