### PR TITLE
(bubble sort) Fix interactive demo

### DIFF
--- a/BubbleSort.rb
+++ b/BubbleSort.rb
@@ -17,6 +17,7 @@ def bubble_sort(array)
 end
 puts "Enter a list of numbers seprated by space"
 
-list = gets 
+list = gets.chomp
+list = list.split(" ").map(&:to_i) 
 bubble_sort(list)
-print list
+puts list


### PR DESCRIPTION
Demo wasn't working because the `#bubble_sort` function was being passed a string instead of an array of numbers.