### PR TITLE
(insertion sort) Fix interactive demo

### DIFF
--- a/InsertionSort.rb
+++ b/InsertionSort.rb
@@ -12,6 +12,7 @@ def insertion_sort(array)
 end
 puts "Enter a list of numbers seprated by space"
 
-list = gets 
+list = gets.chomp
+list = list.split(" ").map(&:to_i) 
 insertion_sort(list)
-print list
+puts list


### PR DESCRIPTION
Demo wasn't working because the `#insertion_sort` function was being passed a string instead of an array of numbers.