### PR TITLE
Fix `NoMethodError` in the quicksort

### DIFF
--- a/Sorting/quicksort.rb
+++ b/Sorting/quicksort.rb
@@ -1,15 +1,15 @@
-def quicksort
-  return [] if empty?
+def quicksort(arr)
+  return [] if arr.empty?
 
   # chose a random pivot value
-  pivot = delete_at(rand(size))
+  pivot = arr.delete_at(rand(arr.size))
   # partition array into 2 arrays and comparing them to each other and eventually returning
   # array with the pivot value sorted
-  left, right = partition(&pivot.method(:>))
+  left, right = arr.partition(&pivot.method(:>))
 
   # recursively calling the quicksort method on itself
-  return *left.quicksort, pivot, *right.quicksort
+  return *quicksort(left), pivot, *quicksort(right)
 end
 
 arr = [34, 2, 1, 5, 3]
-p arr.quicksort
+p quicksort(arr)


### PR DESCRIPTION
The code was raising a `NoMethodError` with the description: 
```
`quicksort.rb:17:in `<main>': private method `quicksort' called for [34, 2, 1, 5, 3]:Array (NoMethodError)`
```

The code was executed using it ruby 2.6.2p47 (2019-03-13 revision 67232) [x86_64-linux]