### PR TITLE
make linked-list implementations more respectful on the Ruby style, and make them enumerable

### DIFF
--- a/data_structures/LinkedLists/double_list.rb
+++ b/data_structures/LinkedLists/double_list.rb
@@ -10,15 +10,16 @@ end
 
 # A Class for double linked lists (each element links to the next one, and to the previous one)
 class DoubleList
+  include Enumerable
   attr_accessor :head, :tail
-  def initialize()
+  def initialize
     @head = nil
     @tail = nil
   end
 
   def insert_tail(value)
     new_node = Node.new(value)
-    if (@head == nil)
+    if @head.nil?
       @head = new_node
       @tail = new_node
     else
@@ -30,7 +31,7 @@ class DoubleList
 
   def insert_head(value)
     new_node = Node.new(value)
-    if (@head == nil)
+    if @head.nil?
       @head = new_node
       @tail = new_node
     else
@@ -40,41 +41,36 @@ class DoubleList
     end
   end
 
-  def delete_tail()
-    if (@tail != nil)
+  def delete_tail
+    until @tail.nil?
       @tail = @tail.prev
-      if (@tail != nil)
-        @tail.next = nil
-      end
+      @tail.next = nil unless @tail.nil?
     end
   end
 
-  def delete_head()
-    if (@head != nil)
+  def delete_head
+    until @head.nil?
       @head = @head.next
-      if (@head != nil)
-        @head.prev = nil
-      end
+      @head.prev = nil unless @head.nil?
     end
   end
 
-  def print_list()
-    print "["
-    if (@head != nil)
-      printNode = @head
-      while (printNode != nil)
-        print "#{printNode.value}"
-        if (printNode != @tail)
-          print ", "
-        end
-        printNode = printNode.next
-      end
+  def each
+    return if @head.nil?
+
+    current = @head
+    until current.nil?
+      yield current.value
+      current = current.next
     end
-    print "]"
-    STDOUT.flush
   end
 
-  def is_empty()
-    return (@head==nil)
+  def print_list
+    # the to_a method is from Enumerable, will call each to get the values, and return an array
+    puts '[' + self.to_a.join(', ') + ']'
+  end
+
+  def empty?
+    @head.nil?
   end
 end

--- a/data_structures/LinkedLists/single_list.rb
+++ b/data_structures/LinkedLists/single_list.rb
@@ -10,27 +10,26 @@ end
 # A Class for single linked lists (each element links to the next one, but not to the previous one)
 
 class SingleList
+  include Enumerable
   attr_accessor :head
-  def initialize()
+  def initialize
     @head = nil
   end
 
   def insert_tail(value)
     newNode = Node.new(value)
-    if (@head == nil)
+    if @head.nil?
       @head = newNode
     else
       tempNode = @head
-      while (tempNode.next != nil)
-        tempNode = tempNode.next
-      end
+      tempNode = tempNode.next until tempNode.next.nil?
       tempNode.next = newNode
     end
   end
 
   def insert_head(value)
     newNode = Node.new(value)
-    if (@head == nil)
+    if @head.nil?
       @head = newNode
     else
       newNode.next = @head
@@ -38,42 +37,38 @@ class SingleList
     end
   end
 
-  def print_list()
-    print "["
-    if (@head != nil)
-      printNode = @head
-      while (printNode != nil)
-        print "#{printNode.value}"
-        if (printNode.next != nil)
-          print ", "
-        end
-        printNode = printNode.next
-      end
+  def each
+    return if @head.nil?
+
+    current = @head
+    until current.nil?
+      yield current.value
+      current = current.next
     end
-    print "]"
-    STDOUT.flush
+  end
+
+  def print_list
+    puts '[' + self.to_a.join(', ') + ']'
   end
 
   def delete_head
-    if (@head != nil) && (@head.next != nil)
+    if !@head.nil? && !@head.next.nil?
       newHead = @head.next
       @head = newHead
-    elsif (@head != nil) && (@head.next == nil)
+    elsif !@head.nil? && @head.next.nil?
       @head = nil
     end
   end
 
   def delete_tail
-    if (@head != nil)
-      tempNode = @head
-      while (tempNode.next.next != nil)
-        tempNode = tempNode.next
-      end
-      tempNode.next = nil
-    end
+    return if @head.nil?
+
+    tempNode = @head
+    tempNode = tempNode.next until tempNode.next.next.nil?
+    tempNode.next = nil
   end
 
-  def isEmpty()
-    return (@head==nil)
+  def empty?
+    @head.nil?
   end
 end


### PR DESCRIPTION
This PR updates the linked-list implementations.

## Code style fixing

updated a few things to clean the code, `rubocop` reports less warnings now, removed unneeded parenthesis pairs on functions that take no arguments, removed unneeded parenthesis pairs from conditions, replaced `x == nil` with `x.nil?`, which is the same.

## Enumerable

instead of traversing the lists only when printing the contents, I moved the traversal to the `each` method, and included `Enumerable`, which provides methods like `first`, `to_a`, `any?`, `all?`, `detect`, `select` and so on, the `print_list` method becomes much simpilier.

Any feedback is welcome.