### PR TITLE
Add tests for Sorting/bogo_sort.rb and run tests on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,12 @@
+name: test
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-ruby@master
+        with:
+          ruby-version: '2.7'
+      - name: Run tests
+        run: rake test

--- a/DIRECTORY.md
+++ b/DIRECTORY.md
@@ -42,7 +42,6 @@
 
 ## Sorting
   * [Bogo Sort](https://github.com/TheAlgorithms/Ruby/blob/master/sorting/bogo_sort.rb)
-  * [Bogo Sort Test](https://github.com/TheAlgorithms/Ruby/blob/master/sorting/bogo_sort_test.rb)
   * [Bubble Sort](https://github.com/TheAlgorithms/Ruby/blob/master/sorting/bubble_sort.rb)
   * [Bucket Sort](https://github.com/TheAlgorithms/Ruby/blob/master/sorting/bucket_sort.rb)
   * [Heap Sort](https://github.com/TheAlgorithms/Ruby/blob/master/sorting/heap_sort.rb)

--- a/DIRECTORY.md
+++ b/DIRECTORY.md
@@ -42,6 +42,7 @@
 
 ## Sorting
   * [Bogo Sort](https://github.com/TheAlgorithms/Ruby/blob/master/sorting/bogo_sort.rb)
+  * [Bogo Sort Test](https://github.com/TheAlgorithms/Ruby/blob/master/sorting/bogo_sort_test.rb)
   * [Bubble Sort](https://github.com/TheAlgorithms/Ruby/blob/master/sorting/bubble_sort.rb)
   * [Bucket Sort](https://github.com/TheAlgorithms/Ruby/blob/master/sorting/bucket_sort.rb)
   * [Heap Sort](https://github.com/TheAlgorithms/Ruby/blob/master/sorting/heap_sort.rb)

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,7 @@
+require 'rake/testtask'
+
+Rake::TestTask.new(:test) do |t|
+  t.test_files = FileList['**/*_test.rb']
+end
+
+task default: :test

--- a/sorting/bogo_sort.rb
+++ b/sorting/bogo_sort.rb
@@ -13,6 +13,8 @@ class Array
   end
 end
 
-puts "Enter a list of numbers separated by space"
-str = gets.chomp.split('')
-puts str.bogosort.join('')
+if $0 == __FILE__
+  puts "Enter a list of numbers separated by space"
+  str = gets.chomp.split('')
+  puts str.bogosort.join('')
+end

--- a/sorting/bogo_sort_test.rb
+++ b/sorting/bogo_sort_test.rb
@@ -1,0 +1,16 @@
+require 'minitest/autorun'
+require_relative './bogo_sort'
+
+class TestBogoSort < Minitest::Test
+  def test_sorted_array
+    input = [1, 2, 3, 4, 5]
+    expected = input.dup
+    assert_equal expected, input.bogosort
+  end
+
+  def test_reversed_array
+    input = [5, 4, 3, 2, 1]
+    expected = [1, 2, 3, 4, 5]
+    assert_equal expected, input.bogosort
+  end
+end


### PR DESCRIPTION
- Adds simple test cases for Sorting/bogo_sort.rb using [minitest](https://github.com/seattlerb/minitest)
- Set up GitHub Actions to run these tests on the latest Ruby (v2.7)
    - To make adding tests easy, uses [`Rake::TestTask`](https://ruby.github.io/rake/Rake/TestTask.html)