### PR TITLE
chore: fix warnings by `ruby -w`

### DIFF
--- a/Sorting/bogo_sort.rb
+++ b/Sorting/bogo_sort.rb
@@ -4,8 +4,8 @@ class Array
     for i in 1...self.length
       return false if self[i-1] > self[i]
     end
-		return true
-	end
+    return true
+  end
   def bogosort
     ### randomly shuffles until sorted
     self.shuffle! until self.sorted?

--- a/Sorting/heap_sort.rb
+++ b/Sorting/heap_sort.rb
@@ -1,7 +1,5 @@
-"""
-Algorithm: Heap-Sort
-Time-Complexity: O(nlogn)
-"""
+# Algorithm: Heap-Sort
+# Time-Complexity: O(nlogn)
 def heap_sort(array)
   array_size = array.size
   adjusted_array = [nil] + array


### PR DESCRIPTION
This PR removes warnings which `ruby -w` emits from `./Sorting/*.rb` files.