### PR TITLE
Remove badges of unused tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,6 @@
 [![Gitter chat](https://img.shields.io/badge/Chat-Gitter-ff69b4.svg?label=Chat&logo=gitter&style=flat-square)](https://gitter.im/TheAlgorithms)&nbsp;
 [![contributions welcome](https://img.shields.io/static/v1.svg?label=Contributions&message=Welcome&color=0059b3&style=flat-square)](https://github.com/TheAlgorithms/Ruby/blob/master/CONTRIBUTING.md)&nbsp;
 ![](https://img.shields.io/github/repo-size/TheAlgorithms/Ruby.svg?label=Repo%20size&style=flat-square)&nbsp;
-[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white&style=flat-square)](https://github.com/pre-commit/pre-commit)&nbsp;
-[![code style: black](https://img.shields.io/static/v1?label=code%20style&message=black&color=black&style=flat-square)](https://github.com/psf/black)&nbsp;
-
 ### All algorithms implemented in Ruby (for education)
 
 These implementations are for learning purposes only. Therefore they may be less efficient than the implementations in the Ruby standard library.


### PR DESCRIPTION
It seems that some badges of unused tools have slipped into README.md when it is updated based on the Python repository (#72).

NOTE:
- pre-commit is a tool to manage git pre-commit hooks. The Python repository uses it to lint and format source files and validate filenames.
    - pre-commit setting: [`.pre-commit-config.yaml`](https://github.com/TheAlgorithms/Python/blob/32def4b3c53a100c40b0cf082799574157775e40/.pre-commit-config.yaml)
    - GitHub Actions to run pre-commit: [`.github/workflows/pre-commit.yml`](https://github.com/TheAlgorithms/Python/blob/fdba34f70464a54f3761e426d50a889c70671677/.github/workflows/pre-commit.yml)
- black is a zero-configuration Python code formatter.
    - Ruby has some code formatters ([rufo](https://github.com/ruby-formatter/rufo), [@prettier/plugin-ruby](https://github.com/prettier/plugin-ruby) and [RuboCop](https://github.com/rubocop-hq/rubocop)), too. Maybe we can introduce them to this repository.