### PR TITLE
Update Ruby from 2.7 to 3.0 on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,6 @@ jobs:
       - uses: actions/checkout@master
       - uses: actions/setup-ruby@master
         with:
-          ruby-version: '2.7'
+          ruby-version: '3.0'
       - name: Run tests
         run: rake test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      - uses: actions/setup-ruby@master
+      - uses: ruby/setup-ruby@master
         with:
           ruby-version: '3.0'
       - name: Run tests


### PR DESCRIPTION
This PR updates Ruby from 2.7 to 3.0 (the latest stable version) on CI.

- All tests are green.
- actions/setup-ruby has not yet supported Ruby 3.0, so replaces it with [ruby/setup-ruby](https://github.com/ruby/setup-ruby).
    - actions/setup-ruby will support Ruby 3.0 when https://github.com/actions/virtual-environments/issues/2357 is deployed. Probably it's not a long time off, but no announcement has been made as to when it will be deployed.