### PR TITLE
Fix the complexity memoization check

### DIFF
--- a/dynamic_programming/fibonacci.rb
+++ b/dynamic_programming/fibonacci.rb
@@ -30,7 +30,7 @@ def fibonacci(number, memo_hash = {})
 end
 
 def memoize(number, memo_hash)
-  return memo_hash[number] if memo_hash.keys.include? number
+  return memo_hash[number] if memo_hash.key? number
 
   memo_hash[number] = memoize(number - 1, memo_hash) + memoize(number - 2, memo_hash)
 


### PR DESCRIPTION
keys.include? number is not cheap as it is search operation on array and it increases the time complexity. replaced it with `key?` method to fix memoisation check part on O(1) complexity