### PR TITLE
Use Ruby 3.2 in testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,6 @@ jobs:
       - uses: actions/checkout@master
       - uses: ruby/setup-ruby@master
         with:
-          ruby-version: '3.1'
+          ruby-version: '3.2'
       - name: Run tests
         run: rake test


### PR DESCRIPTION
This PR bumps Ruby version in CI from 3.1 to 3.2.