### PR TITLE
Temporarily revert new update_directory_md workflow (#209)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,11 @@
-name: Build/test code
+name: test
 on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@master
+      - uses: ruby/setup-ruby@master
         with:
           ruby-version: '3.2'
       - name: Run tests

--- a/.github/workflows/update_directory_md.yml
+++ b/.github/workflows/update_directory_md.yml
@@ -1,30 +1,59 @@
-name: Directory writer
-on:
-  push:
-    branches:
-      - master
-  schedule:
-  #        ┌───────────── minute (0 - 59)
-  #        │  ┌───────────── hour (0 - 23)
-  #        │  │ ┌───────────── day of the month (1 - 31)
-  #        │  │ │ ┌───────────── month (1 - 12 or JAN-DEC)
-  #        │  │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
-  #        │  │ │ │ │
-  #        │  │ │ │ │
-  #        │  │ │ │ │
-  #        *  * * * *
-  - cron: '0 0 * * 1'
+name: update_directory_md
+on: [push]
 jobs:
-  build:
-    if: github.repository == 'TheAlgorithms/Ruby' # We only need this to run in our repository.
+  update_directory_md:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Build directory
-        uses: TheAlgorithms/scripts/directory_md@main
-        with:
-          language: Ruby
-          working-directory: .
-          filetypes: .rb
+      - uses: actions/checkout@master
+      - uses: actions/setup-python@master
+      - name: update_directory_md
+        shell: python
+        run: |
+            import os
+            from typing import Iterator
+            URL_BASE = "https://github.com/TheAlgorithms/Ruby/blob/master"
+            g_output = []
+            
+            def good_filepaths(top_dir: str = ".") -> Iterator[str]:
+                for dirpath, dirnames, filenames in os.walk(top_dir):
+                    dirnames[:] = [d for d in dirnames if d[0] not in "._"]
+                    for filename in filenames:
+                        if os.path.splitext(filename)[1].lower() == ".rb":
+                            yield os.path.join(dirpath, filename).lstrip("./")
+                            
+            def md_prefix(i):
+                return f"{i * '  '}*" if i else "\n##"
+                
+            def print_path(old_path: str, new_path: str) -> str:
+                global g_output
+                old_parts = old_path.split(os.sep)
+                for i, new_part in enumerate(new_path.split(os.sep)):
+                    if i + 1 > len(old_parts) or old_parts[i] != new_part:
+                        if new_part:
+                            g_output.append(f"{md_prefix(i)} {new_part.replace('_', ' ').title()}")
+                return new_path
+                
+            def build_directory_md(top_dir: str = ".") -> str:
+                global g_output
+                old_path = ""
+                for filepath in sorted(good_filepaths(), key=str.lower):
+                    filepath, filename = os.path.split(filepath)
+                    if filepath != old_path:
+                        old_path = print_path(old_path, filepath)
+                    indent = (filepath.count(os.sep) + 1) if filepath else 0
+                    url = "/".join((URL_BASE, filepath, filename)).replace(" ", "%20")
+                    filename = os.path.splitext(filename.replace("_", " ").title())[0]
+                    g_output.append(f"{md_prefix(indent)} [{filename}]({url})")
+                return "\n".join(g_output)
+            with open("DIRECTORY.md", "w") as out_file:
+                out_file.write(build_directory_md(".") + "\n")
+                
+      - name: Update DIRECTORY.md
+        run: |
+          cat DIRECTORY.md
+          git config --global user.name github-actions
+          git config --global user.email '${GITHUB_ACTOR}@users.noreply.github.com'
+          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY
+          git add DIRECTORY.md
+          git commit -am "updating DIRECTORY.md" ||  true
+          git push --force origin HEAD:$GITHUB_REF || true


### PR DESCRIPTION
This PR reverts a new workflow introduced by #209 as an error occurred during execution.

https://github.com/TheAlgorithms/Ruby/actions/runs/5337370931/jobs/9673337632

```
# Build Directory
Run TheAlgorithms/scripts/directory_md@main
Run echo "/home/runner/work/_actions/TheAlgorithms/scripts/main/directory_md" >> $GITHUB_PATH
Run actions/setup-python@v4
Installed versions
Run git config --global user.name github-actions[bot]
Run # If branch exists, change to that branch to prevent multiple committing/PR creation.
error: pathspec 'directory-update' did not match any file(s) known to git
python: can't open file '/home/runner/work/Ruby/Ruby/build_directory_md.py': [Errno 2] No such file or directory
Error: Process completed with exit code 2.
```