### PR TITLE
chore: specify GitHub action versions and remove needless files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,11 @@
-name: test
+name: Build/test code
 on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-      - uses: ruby/setup-ruby@master
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.2'
       - name: Run tests


### PR DESCRIPTION
This change cherry-picks the change that was added in #209 by @Panquesito7. The change was later reverted by #211, but this pull request applies the change again.