### PR TITLE
chore: update `actions/checkout` to `v4`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.2'


### PR DESCRIPTION
This PR updates `actions/checkout` to`v4`.

Regarding this line:
https://github.com/TheAlgorithms/Ruby/blob/6075b3a824df32865c6507649f6680c120fe5c3f/.github/workflows/update_directory_md.yml#L7
The general recommendation is to _pin_ the exact version and not use `@master`.
