### PR TITLE
Use Ruby 3.3 in testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.2'
+          ruby-version: '3.3'
       - name: Run tests
         run: rake test


### PR DESCRIPTION
This PR bumps Ruby version in CI from 3.2 to 3.3.