### PR TITLE
feat: add time-free motion equation helpers

### DIFF
--- a/maths/time_free_equation.rb
+++ b/maths/time_free_equation.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# Solves forms of the kinematic equation:
+# vf^2 - vi^2 = 2 * a * delta_x
+class TimeFreeEquation
+  class << self
+    def displacement(initial_velocity:, final_velocity:, acceleration:)
+      raise ZeroDivisionError, 'acceleration cannot be zero' if acceleration.zero?
+
+      ((final_velocity**2) - (initial_velocity**2)) / (2.0 * acceleration)
+    end
+
+    def acceleration(initial_velocity:, final_velocity:, displacement:)
+      raise ZeroDivisionError, 'displacement cannot be zero' if displacement.zero?
+
+      ((final_velocity**2) - (initial_velocity**2)) / (2.0 * displacement)
+    end
+
+    def final_velocity(initial_velocity:, acceleration:, displacement:)
+      value = (initial_velocity**2) + (2.0 * acceleration * displacement)
+      raise DomainError, 'final velocity is not real for the provided inputs' if value.negative?
+
+      Math.sqrt(value)
+    end
+
+    def initial_velocity(final_velocity:, acceleration:, displacement:)
+      value = (final_velocity**2) - (2.0 * acceleration * displacement)
+      raise DomainError, 'initial velocity is not real for the provided inputs' if value.negative?
+
+      Math.sqrt(value)
+    end
+  end
+end
+
+class DomainError < StandardError; end

--- a/maths/time_free_equation_test.rb
+++ b/maths/time_free_equation_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require_relative './time_free_equation'
+
+class TimeFreeEquationTest < Minitest::Test
+  def test_displacement
+    assert_in_delta 24.0,
+                    TimeFreeEquation.displacement(initial_velocity: 2.0, final_velocity: 10.0, acceleration: 2.0),
+                    1E-12
+  end
+
+  def test_acceleration
+    assert_in_delta 3.0,
+                    TimeFreeEquation.acceleration(initial_velocity: 4.0, final_velocity: 10.0, displacement: 14.0),
+                    1E-12
+  end
+
+  def test_final_velocity
+    assert_in_delta 13.0,
+                    TimeFreeEquation.final_velocity(initial_velocity: 5.0, acceleration: 3.0, displacement: 24.0),
+                    1E-12
+  end
+
+  def test_initial_velocity
+    assert_in_delta 6.0,
+                    TimeFreeEquation.initial_velocity(final_velocity: 14.0, acceleration: 4.0, displacement: 20.0),
+                    1E-12
+  end
+
+  def test_domain_error_for_imaginary_velocity
+    assert_raises DomainError do
+      TimeFreeEquation.final_velocity(initial_velocity: 1.0, acceleration: -10.0, displacement: 1.0)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add `TimeFreeEquation` helpers around `vf^2 - vi^2 = 2*a*delta_x`
- support solving for displacement, acceleration, final velocity, and initial velocity
- add domain checks for non-real velocity solutions and unit tests

## Testing
- `ruby maths/time_free_equation_test.rb`

Fixes #193
