### PR TITLE
feat: add free-fall motion calculations

### DIFF
--- a/maths/free_fall_distance.rb
+++ b/maths/free_fall_distance.rb
@@ -2,25 +2,23 @@
 
 # Free-fall helpers based on constant acceleration motion.
 class FreeFallDistance
-  class << self
-    STANDARD_GRAVITY = 9.80665
+  STANDARD_GRAVITY = 9.80665
 
+  class << self
     # d = 0.5 * g * t^2
     def distance(time:, gravity: STANDARD_GRAVITY)
-      raise DomainError, 'time must be non-negative' if time.negative?
-      raise DomainError, 'gravity must be positive' unless gravity.positive?
+      raise ArgumentError, 'time must be non-negative' if time.negative?
+      raise ArgumentError, 'gravity must be positive' unless gravity.positive?
 
       0.5 * gravity * time * time
     end
 
     # t = sqrt(2d / g)
     def time(distance:, gravity: STANDARD_GRAVITY)
-      raise DomainError, 'distance must be non-negative' if distance.negative?
-      raise DomainError, 'gravity must be positive' unless gravity.positive?
+      raise ArgumentError, 'distance must be non-negative' if distance.negative?
+      raise ArgumentError, 'gravity must be positive' unless gravity.positive?
 
       Math.sqrt((2.0 * distance) / gravity)
     end
   end
 end
-
-class DomainError < StandardError; end

--- a/maths/free_fall_distance.rb
+++ b/maths/free_fall_distance.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Free-fall helpers based on constant acceleration motion.
+class FreeFallDistance
+  class << self
+    STANDARD_GRAVITY = 9.80665
+
+    # d = 0.5 * g * t^2
+    def distance(time:, gravity: STANDARD_GRAVITY)
+      raise DomainError, 'time must be non-negative' if time.negative?
+      raise DomainError, 'gravity must be positive' unless gravity.positive?
+
+      0.5 * gravity * time * time
+    end
+
+    # t = sqrt(2d / g)
+    def time(distance:, gravity: STANDARD_GRAVITY)
+      raise DomainError, 'distance must be non-negative' if distance.negative?
+      raise DomainError, 'gravity must be positive' unless gravity.positive?
+
+      Math.sqrt((2.0 * distance) / gravity)
+    end
+  end
+end
+
+class DomainError < StandardError; end

--- a/maths/free_fall_distance_test.rb
+++ b/maths/free_fall_distance_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require_relative './free_fall_distance'
+
+class FreeFallDistanceTest < Minitest::Test
+  def test_distance_from_time
+    assert_in_delta 19.6133, FreeFallDistance.distance(time: 2.0), 1E-4
+  end
+
+  def test_time_from_distance
+    assert_in_delta 2.0, FreeFallDistance.time(distance: 19.6133), 1E-4
+  end
+
+  def test_negative_time_raises
+    assert_raises DomainError do
+      FreeFallDistance.distance(time: -1.0)
+    end
+  end
+
+  def test_negative_distance_raises
+    assert_raises DomainError do
+      FreeFallDistance.time(distance: -1.0)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add free-fall helper methods using constant acceleration formulas
- implement both distance from time and time from distance calculations
- add input validation and tests

## Testing
- `ruby maths/free_fall_distance_test.rb`

Fixes #194
